### PR TITLE
Add createdAt to CreateThreadRequest

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -35,6 +35,7 @@ export type CreateThreadRequest = {
   messages: CreateMessageRequest[];
   metadata?: Metadata;
   externalUser?: CreateExternalUserRequest;
+  createdAt?: string;
 };
 
 export type CreateFeedbackRequest = {


### PR DESCRIPTION
I noticed that the online documentation (https://docs.melodi.fyi/integrating-melodi-analytics/sdks) mentions that `createdAt` can be passed in a `CreateThreadRequest`, but this field isn't available in the type definition. I made it a string because that's what the other createdAt fields are and it looks like the request is passed straightshot over the wire, but apologies if this is incorrect.